### PR TITLE
switch to output: "hybrid"

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import react from "@astrojs/react";
 
 // https://astro.build/config
 export default defineConfig({
-  output: "server",
+  output: "hybrid",
   adapter: netlify(),
   experimental: {
     actions: true,


### PR DESCRIPTION
This breaks the Astro Actions functionality on Netlify.